### PR TITLE
snt957w_tde_temp: high temp. limit should be optional

### DIFF
--- a/custom_components/tuya_local/devices/snt957w_tde_temp.yaml
+++ b/custom_components/tuya_local/devices/snt957w_tde_temp.yaml
@@ -42,6 +42,7 @@ secondary_entities:
           max: 1200
         mapping:
           - scale: 10
+        optional: true
   - entity: number
     name: Low temperature limit
     category: config


### PR DESCRIPTION
This device was working fine with tuya-local as long as it was added to Tuya app. But once I used cloudcut it, suddenly tuya-local could not recognize it anymore (saying that device is unsupported). Inspection of the yaml revealed that the device broadcasts matching dpids except for dpid 10. This could be because I removed the device from Tuya app and it reset to factory defaults.

TLDR: making this optional makes the device detectable again.